### PR TITLE
feat: re-export prost_types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 pub use prost_types;
 pub mod logproto {
     tonic::include_proto!("logproto");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
+pub use prost_types;
 pub mod logproto {
     tonic::include_proto!("logproto");
 }


### PR DESCRIPTION
It is needed in certain places. Like [this code](https://github.com/GreptimeTeam/greptimedb/blob/ab4663ec2b0438a80c182a70e7df78e0c74b7bab/src/servers/src/http/loki.rs#L34)